### PR TITLE
feat: fix compile

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -75,12 +75,12 @@ macro_rules! gpio_trait {
 
             fn set_high(&self, pos: u8) {
                 // NOTE(unsafe) atomic write to a stateless register
-                unsafe { self.bsrr().write(|w| w.bits(1 << pos)) }
+                unsafe { self.bsrr().write(|w| w.bits(1 << pos)) };
             }
 
             fn set_low(&self, pos: u8) {
                 // NOTE(unsafe) atomic write to a stateless register
-                unsafe { self.bsrr().write(|w| w.bits(1 << (pos + 16))) }
+                unsafe { self.bsrr().write(|w| w.bits(1 << (pos + 16))) };
             }
         }
     };
@@ -474,7 +474,7 @@ macro_rules! gpio {
                                 w.bits(r.bits() & reset | mask)
                             }),
                             _ => unreachable!(),
-                        }
+                        };
                         exti.listen(Event::from_code($i), edge);
                         $PXi { _mode: PhantomData }
                     }

--- a/src/power.rs
+++ b/src/power.rs
@@ -55,11 +55,11 @@ impl Power {
 
     pub fn clear_wakeup_flag<L: Into<WakeUp>>(&mut self, lane: L) {
         match lane.into() {
-            WakeUp::Line1 => self.rb.scr().write(|w| w.cwuf1().set_bit()),
-            WakeUp::Line2 => self.rb.scr().write(|w| w.cwuf2().set_bit()),
-            WakeUp::Line3 => self.rb.scr().write(|w| w.cwuf3().set_bit()),
-            WakeUp::Line4 => self.rb.scr().write(|w| w.cwuf4().set_bit()),
-            WakeUp::Line6 => self.rb.scr().write(|w| w.cwuf6().set_bit()),
+            WakeUp::Line1 => _ = self.rb.scr().write(|w| w.cwuf1().set_bit()),
+            WakeUp::Line2 => _ = self.rb.scr().write(|w| w.cwuf2().set_bit()),
+            WakeUp::Line3 => _ = self.rb.scr().write(|w| w.cwuf3().set_bit()),
+            WakeUp::Line4 => _ = self.rb.scr().write(|w| w.cwuf4().set_bit()),
+            WakeUp::Line6 => _ = self.rb.scr().write(|w| w.cwuf6().set_bit()),
             _ => {}
         }
     }
@@ -93,7 +93,7 @@ impl Power {
                 self.rb.cr3().modify(|_, w| w.ewup6().set_bit());
                 self.rb.cr4().modify(|_, w| w.wp6().bit(edge));
             }
-            WakeUp::InternalLine => self.rb.cr3().modify(|_, w| w.eiwul().set_bit()),
+            WakeUp::InternalLine => _ = self.rb.cr3().modify(|_, w| w.eiwul().set_bit()),
         }
     }
 
@@ -105,7 +105,7 @@ impl Power {
             WakeUp::Line4 => self.rb.cr3().modify(|_, w| w.ewup4().clear_bit()),
             WakeUp::Line6 => self.rb.cr3().modify(|_, w| w.ewup6().clear_bit()),
             WakeUp::InternalLine => self.rb.cr3().modify(|_, w| w.eiwul().clear_bit()),
-        }
+        };
     }
 
     pub fn set_mode(&mut self, _mode: PowerMode) {

--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -115,10 +115,10 @@ bus! {
     DMA => (AHB, dma1en, dma1smen, dma1rst), // 0
 
     DBG => (APB1, dbgen, dbgsmen, dbgrst), // 27
-    I2C => (APB1, i2c1en, i2c1smen, i2c1rst), // 21
+    I2C1 => (APB1, i2c1en, i2c1smen, i2c1rst), // 21
     PWR => (APB1, pwren, pwrsmen, pwrrst), // 28
 
-    SPI => (APB2, spi1en, spi1smen, spi1rst), // 14
+    SPI1 => (APB2, spi1en, spi1smen, spi1rst), // 14
     TIM3 => (APB1, tim3en, tim3smen, tim3rst), // 1
     USART2 => (APB1, usart2en, usart2smen, usart2rst), // 17
     WWDG => (APB1, wwdgen, wwdgsmen,), // 11

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,6 +1,6 @@
 use crate::gpio::*;
 use crate::rcc::*;
-use crate::stm32::SPI;
+use crate::stm32::SPI1;
 use crate::time::Hertz;
 use core::ptr;
 pub use hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
@@ -279,7 +279,7 @@ macro_rules! spi {
 }
 
 spi!(
-    SPI,
+    SPI1,
     spi1,
     sck: [
         (PA1<DefaultMode>, AltFunction::AF0),

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -122,17 +122,17 @@ macro_rules! opm_hal {
 }
 
 opm_hal! {
-    TIM1: (Channel1, cc1e, ccmr1_output, oc1m1, oc1fe, ccr1),
-    TIM1: (Channel2, cc2e, ccmr1_output, oc2m1, oc2fe, ccr2),
-    TIM1: (Channel3, cc3e, ccmr2_output, oc3m1, oc3fe, ccr3),
-    TIM1: (Channel4, cc4e, ccmr2_output, oc4m1, oc4fe, ccr4),
-    TIM3: (Channel1, cc1e, ccmr1_output, oc1m1, oc1fe, ccr1),
-    TIM3: (Channel2, cc2e, ccmr1_output, oc2m1, oc2fe, ccr2),
-    TIM3: (Channel3, cc3e, ccmr2_output, oc3m1, oc3fe, ccr3),
-    TIM3: (Channel4, cc4e, ccmr2_output, oc4m1, oc4fe, ccr4),
-    TIM14: (Channel1, cc1e, ccmr1_output, oc1m1, oc1fe, ccr1),
-    TIM16: (Channel1, cc1e, ccmr1_output, oc1m1, oc1fe, ccr1),
-    TIM17: (Channel1, cc1e, ccmr1_output, oc1m1, oc1fe, ccr1),
+    TIM1: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM1: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2),
+    TIM1: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3),
+    TIM1: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4),
+    TIM3: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM3: (Channel2, cc2e, ccmr1_output, oc2m, oc2fe, ccr2),
+    TIM3: (Channel3, cc3e, ccmr2_output, oc3m, oc3fe, ccr3),
+    TIM3: (Channel4, cc4e, ccmr2_output, oc4m, oc4fe, ccr4),
+    TIM14: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM16: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
+    TIM17: (Channel1, cc1e, ccmr1_output, oc1m, oc1fe, ccr1),
 }
 
 opm! {

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -92,7 +92,7 @@ macro_rules! pwm {
                         $(
                             self.tim.arr().modify(|_, w| w.$arr_h().bits((arr >> 16) as u16));
                         )*
-                        self.tim.cr1().write(|w| w.cen().set_bit())
+                        self.tim.cr1().write(|w| w.cen().set_bit());
                     }
                 }
                 /// Starts listening
@@ -169,7 +169,7 @@ macro_rules! pwm_hal {
                 }
 
                 fn set_duty(&mut self, duty: u32) {
-                    unsafe { (*$TIMX::ptr()).$ccrx().write(|w| w.bits(duty)) }
+                    unsafe { (*$TIMX::ptr()).$ccrx().write(|w| w.bits(duty)) };
                 }
             }
         )+
@@ -183,7 +183,7 @@ macro_rules! pwm_advanced_hal {
         $ccmrx_output:ident,
         $ocxpe:ident,
         $ocxm:ident,
-        $ccrx:ident
+        $ccrx:expr
         $(, $moe:ident)*
     ) ,)+
     ) => {
@@ -212,7 +212,7 @@ macro_rules! pwm_advanced_hal {
                 }
 
                 fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).$ccrx().read().$ccrx().bits() }
+                    unsafe { (*$TIMX::ptr()).ccr($ccrx).read().ccr().bits() }
                 }
 
                 fn get_max_duty(&self) -> u16 {
@@ -220,7 +220,7 @@ macro_rules! pwm_advanced_hal {
                 }
 
                 fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).$ccrx().write(|w| w.$ccrx().bits(duty)) }
+                    unsafe { (*$TIMX::ptr()).ccr($ccrx).write(|w| w.ccr().bits(duty)) };
                 }
             }
 
@@ -237,20 +237,20 @@ macro_rules! pwm_advanced_hal {
 }
 
 pwm_advanced_hal! {
-    TIM1:  (Channel1, cc1e: cc1ne, ccmr1_output, oc1pe, oc1m1, ccr1, moe),
-    TIM1:  (Channel2, cc2e: cc2ne, ccmr1_output, oc2pe, oc2m1, ccr2, moe),
-    TIM1:  (Channel3, cc3e: cc3ne, ccmr2_output, oc3pe, oc3m1, ccr3, moe),
-    TIM1:  (Channel4, cc4e, ccmr2_output, oc4pe, oc4m1, ccr4, moe),
-    TIM14: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m1, ccr1),
-    TIM16: (Channel1, cc1e: cc1ne, ccmr1_output, oc1pe, oc1m1, ccr1, moe),
-    TIM17: (Channel1, cc1e: cc1ne, ccmr1_output, oc1pe, oc1m1, ccr1, moe),
+    TIM1:  (Channel1, cc1e: cc1ne, ccmr1_output, oc1pe, oc1m, 1, moe),
+    TIM1:  (Channel2, cc2e: cc2ne, ccmr1_output, oc2pe, oc2m, 2, moe),
+    TIM1:  (Channel3, cc3e: cc3ne, ccmr2_output, oc3pe, oc3m, 3, moe),
+    TIM1:  (Channel4, cc4e, ccmr2_output, oc4pe, oc4m, 4, moe),
+    TIM14: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m, 1),
+    TIM16: (Channel1, cc1e: cc1ne, ccmr1_output, oc1pe, oc1m, 1, moe),
+    TIM17: (Channel1, cc1e: cc1ne, ccmr1_output, oc1pe, oc1m, 1, moe),
 }
 
 pwm_hal! {
-    TIM3: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m1, ccr1, ccr1_l, ccr1_h),
-    TIM3: (Channel2, cc2e, ccmr1_output, oc2pe, oc2m1, ccr2, ccr2_l, ccr2_h),
-    TIM3: (Channel3, cc3e, ccmr2_output, oc3pe, oc3m1, ccr3, ccr3_l, ccr3_h),
-    TIM3: (Channel4, cc4e, ccmr2_output, oc4pe, oc4m1, ccr4, ccr4_l, ccr4_h),
+    TIM3: (Channel1, cc1e, ccmr1_output, oc1pe, oc1m, ccr1, ccr1_l, ccr1_h),
+    TIM3: (Channel2, cc2e, ccmr1_output, oc2pe, oc2m, ccr2, ccr2_l, ccr2_h),
+    TIM3: (Channel3, cc3e, ccmr2_output, oc3pe, oc3m, ccr3, ccr3_l, ccr3_h),
+    TIM3: (Channel4, cc4e, ccmr2_output, oc4pe, oc4m, ccr4, ccr4_l, ccr4_h),
 }
 
 pwm! {


### PR DESCRIPTION
This fixes compilation of the hal (which I presume broke because of stm32-rs nightly changes).

I've tested the three blinkey examples on a stm32c071rbt6 (nucleo board) and they seem to work as expected. 

Let me know if there are other verification steps that should be done.