### PR TITLE
chore: migrate probe-run -> probe-rs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.thumbv6m-none-eabi]
 # runner = "arm-none-eabi-gdb -q"
-runner = "probe-run --chip STM32C031C6T3"
+runner = "probe-rs run --chip STM32C031C6T3"
 
 rustflags = [
   "-C", "linker=arm-none-eabi-ld",


### PR DESCRIPTION
Probe-run is [depreciated](https://github.com/knurling-rs/probe-run/commit/8f315e763d99ca0a6014f6452b1a077c32f372a0) as of October 2023. This commit switches the flasher to use [probe-rs](https://github.com/probe-rs/probe-rs) which is actively maintained.