### PR TITLE
feat: stm32c071 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ device-selected = []
 rt = ["stm32c0/rt"]
 stm32c011 = ["stm32c0/stm32c011", "device-selected"]
 stm32c031 = ["stm32c0/stm32c031", "device-selected"]
+stm32c071 = ["stm32c0/stm32c071", "device-selected"]
 
 i2c-blocking = []
 i2c-nonblocking = []

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -23,6 +23,8 @@ pub enum Event {
     GPIO15 = 15,
     RTC = 19,
     I2C1 = 23,
+    #[cfg(feature = "stm32c071")]
+    I2C2 = 24,
     USART1 = 25,
     LSE_CSS = 31,
 }

--- a/src/i2c/blocking.rs
+++ b/src/i2c/blocking.rs
@@ -6,6 +6,9 @@ use crate::rcc::*;
 use crate::stm32::I2C;
 use hal::blocking::i2c::{Read, Write, WriteRead};
 
+#[cfg(feature = "stm32c071")]
+use crate::stm32::I2C2;
+
 pub trait I2cSlave {
     /// Enable/Disable Slave Byte Control. Default SBC is switched on.
     /// For master write/read the transaction should start with sbc disabled.
@@ -519,5 +522,27 @@ i2c!(
         (PB6<Output<OpenDrain>>, AltFunction::AF6),
         (PB8<Output<OpenDrain>>, AltFunction::AF6),
         (PB7<Output<OpenDrain>>, AltFunction::AF14),
+    ],
+);
+
+#[cfg(feature = "stm32c071")]
+i2c!(
+    I2C2,
+    i2c2,
+    sda: [
+        (PA6<Output<OpenDrain>>, AltFunction::AF6),
+        (PA12<Output<OpenDrain>>, AltFunction::AF6),
+        (PA10<Output<OpenDrain>>, AltFunction::AF8),
+        (PB4<Output<OpenDrain>>, AltFunction::AF6),
+        (PB11<Output<OpenDrain>>, AltFunction::AF6),
+        (PB14<Output<OpenDrain>>, AltFunction::AF6),
+    ],
+    scl: [
+        (PA7<Output<OpenDrain>>, AltFunction::AF6),
+        (PA11<Output<OpenDrain>>, AltFunction::AF6),
+        (PA9<Output<OpenDrain>>, AltFunction::AF8),
+        (PB3<Output<OpenDrain>>, AltFunction::AF5),
+        (PB10<Output<OpenDrain>>, AltFunction::AF6),
+        (PB13<Output<OpenDrain>>, AltFunction::AF6),
     ],
 );

--- a/src/i2c/nonblocking.rs
+++ b/src/i2c/nonblocking.rs
@@ -7,6 +7,9 @@ use crate::rcc::*;
 use crate::stm32::I2C;
 use nb::Error::{Other, WouldBlock};
 
+#[cfg(feature = "stm32c071")]
+use crate::stm32::I2C2;
+
 pub trait I2cControl {
     /// Start listening for an interrupt event, will also enable non_blocking mode
     fn listen(&mut self);
@@ -602,5 +605,27 @@ i2c!(
         (PB6<Output<OpenDrain>>, AltFunction::AF6),
         (PB8<Output<OpenDrain>>, AltFunction::AF6),
         (PB7<Output<OpenDrain>>, AltFunction::AF14),
+    ],
+);
+
+#[cfg(feature = "stm32c071")]
+i2c!(
+    I2C2,
+    i2c2,
+    sda: [
+        (PA6<Output<OpenDrain>>, AltFunction::AF6),
+        (PA12<Output<OpenDrain>>, AltFunction::AF6),
+        (PA10<Output<OpenDrain>>, AltFunction::AF8),
+        (PB4<Output<OpenDrain>>, AltFunction::AF6),
+        (PB11<Output<OpenDrain>>, AltFunction::AF6),
+        (PB14<Output<OpenDrain>>, AltFunction::AF6),
+    ],
+    scl: [
+        (PA7<Output<OpenDrain>>, AltFunction::AF6),
+        (PA11<Output<OpenDrain>>, AltFunction::AF6),
+        (PA9<Output<OpenDrain>>, AltFunction::AF8),
+        (PB3<Output<OpenDrain>>, AltFunction::AF5),
+        (PB10<Output<OpenDrain>>, AltFunction::AF6),
+        (PB13<Output<OpenDrain>>, AltFunction::AF6),
     ],
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub use stm32c0::stm32c011 as stm32;
 #[cfg(feature = "stm32c031")]
 pub use stm32c0::stm32c031 as stm32;
 
+#[cfg(feature = "stm32c071")]
+pub use stm32c0::stm32c071 as stm32;
+
 #[cfg(feature = "rt")]
 pub use crate::stm32::interrupt;
 

--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -137,3 +137,8 @@ bus! {
     GPIOD => (IOP, gpioden, gpiodsmen, gpiodrst), // 3
     GPIOF => (IOP, gpiofen, gpiofsmen, gpiofrst), // 5
 }
+
+#[cfg(feature = "stm32c071")]
+bus! {
+    I2C2 => (APB1, i2c2en, i2c2smen, i2c2rst), // 21
+}

--- a/src/timer/opm.rs
+++ b/src/timer/opm.rs
@@ -67,7 +67,7 @@ macro_rules! opm {
                     unsafe {
                         let tim = &*$TIMX::ptr();
                         tim.psc().write(|w| w.psc().bits(psc as u16));
-                        tim.arr().write(|w| w.$arr().bits(reload as u16));
+                        tim.arr().write(|w| w.$arr().bits((reload as u16).into()));
                         $(
                             tim.arr.modify(|_, w| w.$arr_h().bits((reload >> 16) as u16));
                         )*

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -88,7 +88,7 @@ macro_rules! pwm {
 
                     unsafe {
                         self.tim.psc().write(|w| w.psc().bits(psc as u16));
-                        self.tim.arr().write(|w| w.$arr().bits(arr as u16));
+                        self.tim.arr().write(|w| w.$arr().bits((arr as u16).into()));
                         $(
                             self.tim.arr().modify(|_, w| w.$arr_h().bits((arr >> 16) as u16));
                         )*

--- a/src/timer/qei.rs
+++ b/src/timer/qei.rs
@@ -83,7 +83,7 @@ macro_rules! qei {
                 type Count = u16;
 
                 fn count(&self) -> u16 {
-                    self.tim.cnt().read().$cnt().bits()
+                    self.tim.cnt().read().$cnt().bits() as u16
                 }
 
                 fn direction(&self) -> Direction {


### PR DESCRIPTION
Adds support for the stm32c071 device family. 

All the blinkey examples have been verified to work on a stm32c071rbt6 (nucleo) board.

Have not tested the other supported devices, but they still compile.

Implemented Features:
* I2C2

Depends on https://github.com/stm32-rs/stm32c0xx-hal/pull/4